### PR TITLE
Client configuration

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -44,6 +44,7 @@ elastica:
 		url: null
 		proxy: null
 		transport: null
+		compression: false
 		persistent: true
 		timeout: null
 		connections: []
@@ -53,11 +54,13 @@ elastica:
 		username: null
 		password: null
 		auth_type: null
+		curl: []
+		headers: []
 ```
 Extension does not pass any unset values to elastica so elastica defaults just work.
 Take a look to [Elastica docs](https://elastica-docs.readthedocs.io/en/latest/client.html#client-configurations).
 
-## Usage**
+## Usage
 
 Extension registers `Contributte\Elastica\Client` to DI container.
 

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -29,36 +29,35 @@ Define at least one host, this would be minimal possible config.
 
 ```neon
 elastica:
-	hosts:
-		es01:
-			host: localhost
+	config:
+		host: localhost
 ```
 
 Full config
 ```neon
 elastica:
 	debug: %debugMode%
-	hosts:
-		es01:
+	config:
 		host: null
 		port: null
-		username: null
-		password: null
 		path: null
 		url: null
 		proxy: null
-		persistent: null
+		transport: null
+		persistent: true
 		timeout: null
-		connections: null
+		connections: []
 		roundRobin: null
-		log: null
-		retryOnConflict: null
+		retryOnConflict: 0
 		bigintConversion: null
+		username: null
+		password: null
+		auth_type: null
 ```
 Extension does not pass any unset values to elastica so elastica defaults just work.
 Take a look to [Elastica docs](https://elastica-docs.readthedocs.io/en/latest/client.html#client-configurations).
 
-## Usage
+## Usage**
 
 Extension registers `Contributte\Elastica\Client` to DI container.
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "php": ">=7.2",
     "ruflin/elastica": "^7.0",
     "nette/di": "^3.0",
-    "nette/utils": "^3.0"
+    "nette/utils": "^3.0",
+    "nette/schema": "^1.2"
   },
   "require-dev": {
     "tracy/tracy": "^2.6",

--- a/src/DI/ElasticaExtension.php
+++ b/src/DI/ElasticaExtension.php
@@ -21,25 +21,36 @@ class ElasticaExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		// https://github.com/ruflin/Elastica/blob/master/src/ClientConfiguration.php#L26
+		$clientConfig = [
+			'host' => Expect::string()->nullable()->dynamic(),
+			'port' => Expect::int()->nullable()->dynamic(),
+			'path' => Expect::string()->nullable(),
+			'url' => Expect::string()->nullable(),
+			'proxy' => Expect::string()->nullable(),
+			'transport' => Expect::string()->nullable(),
+			'compression' => Expect::bool(),
+			'persistent' => Expect::bool(),
+			'timeout' => Expect::int()->nullable(),
+			'retryOnConflict' => Expect::int(),
+			'bigintConversion' => Expect::bool(),
+			'username' => Expect::string()->nullable()->dynamic(),
+			'password' => Expect::string()->nullable()->dynamic(),
+			'auth_type' => Expect::anyOf('basic', 'digest', 'gssnegotiate', 'ntlm')->nullable()->dynamic(),
+			'curl' => Expect::arrayOf('mixed', 'int'),
+			'headers' => Expect::arrayOf('string', 'string'),
+		];
+
 		return Expect::structure([
 			'debug' => Expect::bool(false),
-			'config' => Expect::structure([
-				'host' => Expect::string()->nullable()->dynamic(),
-				'port' => Expect::int()->nullable()->dynamic(),
-				'path' => Expect::string()->nullable(),
-				'url' => Expect::string()->nullable(),
-				'proxy' => Expect::string()->nullable(),
-				'transport' => Expect::string()->nullable(),
-				'persistent' => Expect::bool(),
-				'timeout' => Expect::int()->nullable(),
-				'connections' => Expect::array(), // host, port, path, transport, compression, persistent, timeout, username, password, auth_type, config -> (curl, headers, url)
-				'roundRobin' => Expect::bool(),
-				'retryOnConflict' => Expect::int(),
-				'bigintConversion' => Expect::bool(),
-				'username' => Expect::string()->nullable()->dynamic(),
-				'password' => Expect::string()->nullable()->dynamic(),
-				'auth_type' => Expect::string()->nullable()->dynamic(), //basic, digest, gssnegotiate, ntlm
-			])->skipDefaults()->castTo('array'),
+			'config' => Expect::structure(array_merge(
+				$clientConfig,
+				[
+					'connections' => Expect::arrayOf(
+						Expect::structure($clientConfig)->skipDefaults()->castTo('array')
+					),
+					'roundRobin' => Expect::bool(),
+				]
+			))->skipDefaults()->castTo('array'),
 		]);
 	}
 

--- a/src/DI/ElasticaExtension.php
+++ b/src/DI/ElasticaExtension.php
@@ -20,29 +20,26 @@ class ElasticaExtension extends CompilerExtension
 
 	public function getConfigSchema(): Schema
 	{
-		// https://elastica-docs.readthedocs.io/en/latest/client.html#client-configurations
+		// https://github.com/ruflin/Elastica/blob/master/src/ClientConfiguration.php#L26
 		return Expect::structure([
 			'debug' => Expect::bool(false),
-			'hosts' => Expect::arrayOf(
-				Expect::structure([
-					'port' => Expect::int(),
-					'path' => Expect::string(),
-					'host' => Expect::string(),
-					'url' => Expect::string(),
-					'proxy' => Expect::string(),
-					'transport' => Expect::string(),
-					'persistent' => Expect::bool(),
-					'timeout' => Expect::int(),
-					'connections' => Expect::array(),
-					'roundRobin' => Expect::bool(),
-					'compression' => Expect::bool(),
-					'log' => Expect::anyOf(Expect::bool(), Expect::string()),
-					'retryOnConflict' => Expect::int(),
-					'bigintConversion' => Expect::bool(),
-					'username' => Expect::string(),
-					'password' => Expect::string(),
-				])->castTo('array')
-			),
+			'config' => Expect::structure([
+				'host' => Expect::string()->nullable()->dynamic(),
+				'port' => Expect::int()->nullable()->dynamic(),
+				'path' => Expect::string()->nullable(),
+				'url' => Expect::string()->nullable(),
+				'proxy' => Expect::string()->nullable(),
+				'transport' => Expect::string()->nullable(),
+				'persistent' => Expect::bool(),
+				'timeout' => Expect::int()->nullable(),
+				'connections' => Expect::array(), // host, port, path, transport, compression, persistent, timeout, username, password, auth_type, config -> (curl, headers, url)
+				'roundRobin' => Expect::bool(),
+				'retryOnConflict' => Expect::int(),
+				'bigintConversion' => Expect::bool(),
+				'username' => Expect::string()->nullable()->dynamic(),
+				'password' => Expect::string()->nullable()->dynamic(),
+				'auth_type' => Expect::string()->nullable()->dynamic(), //basic, digest, gssnegotiate, ntlm
+			])->skipDefaults()->castTo('array'),
 		]);
 	}
 
@@ -52,7 +49,7 @@ class ElasticaExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		$elastica = $builder->addDefinition($this->prefix('client'))
-			->setFactory(ContributteClient::class, [$this->config->hosts]);
+			->setFactory(ContributteClient::class, [$this->config->config]);
 
 		if ($this->config->debug) {
 			$builder->addDefinition($this->prefix('panel'))


### PR DESCRIPTION
Hi,
when integrating the extension into our project, I found out that the Client configuration has an invalid structure and also that default (null) values are getting into the Client.

Current configuration example:

```neon
contributte.elastica:
	debug: %debugMode%
	hosts:
		es01:
			host: elasticsearch
			port: 9200
```

```php
<?php
​
public function createServiceContributte__elastica__client(): Contributte\Elastica\Client
{
	$service = new Contributte\Elastica\Client(
		[
			'es01' => [
				'host' => 'elasticsearch',
				'port' => 9200,
				'path' => null,
				'url' => null,
				'proxy' => null,
				'transport' => null,
				'persistent' => null,
				'timeout' => null,
				'connections' => [],
				'roundRobin' => null,
				'compression' => null,
				'log' => null,
				'retryOnConflict' => null,
				'bigintConversion' => null,
				'username' => null,
				'password' => null,
			],
		],
		null,
		$this->getService('contributte.monolog.logger.default')
	);
	$this->getService('contributte.elastica.panel')->register($service);
	return $service;
}
```

But options for the default Client should be in the configuration root. In the case of multiple nodes, they are defined under the key `connections`.

New configuration example:

```neon
contributte.elastica:
	debug: %debugMode%
	config:
		host: elasticsearch
		port: 9200
```

```php
public function createServiceContributte__elastica__client(): Contributte\Elastica\Client
{
	$service = new Contributte\Elastica\Client(
		['host' => 'elasticsearch`, 'port' => 9200],
		null,
		$this->getService('contributte.monolog.logger.default')
	);
	$this->getService('contributte.elastica.panel')->register($service);
	return $service;
}
```

I also marked options `host`, `port`, `username`, `password` and `auth_type` as dynamic - parameters, env variables etc. are allowed.

Package `nette/schema` is required because of usage of the method `::skipDefaults()` that has been added in the version `^1.2`.