### PR TITLE
Property Nette\PhpGenerator\ClassType::$methods is deprecated, use Nette\PhpGenerator\ClassType::getMethods()

### DIFF
--- a/src/DI/ElasticaExtension.php
+++ b/src/DI/ElasticaExtension.php
@@ -64,7 +64,7 @@ class ElasticaExtension extends CompilerExtension
 
 	public function afterCompile(ClassType $class): void
 	{
-		$initialize = $class->methods['initialize'];
+		$initialize = $class->getMethod('initialize');
 		$initialize->addBody('?::getBlueScreen()->addPanel(?);', [new PhpLiteral(Debugger::class), Panel::class . '::renderException']);
 	}
 


### PR DESCRIPTION

[Property Nette\PhpGenerator\ClassType::$methods is deprecated, use Nette\PhpGenerator\ClassType::getMethods()

(Nette/di v3.0.12 -> v3.0.13)


PS: je to muj prvni PR, pokud jsem neco udelal blbe, tak se omlouvam.